### PR TITLE
Avoid io.ReadAll to just read the file headers

### DIFF
--- a/unpack.go
+++ b/unpack.go
@@ -64,17 +64,17 @@ type headerReader struct {
 func newHeaderReader(r io.Reader, headerSize int) (*headerReader, error) {
 	// read at least headerSize bytes. If EOF, capture whatever was read.
 	buf := make([]byte, headerSize)
-	n, err := io.ReadAtLeast(r, buf, headerSize)
+	n, err := io.ReadFull(r, buf)
 	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		return nil, err
 	}
 	return &headerReader{r, buf[:n]}, nil
 }
 
-func (p *headerReader) Read(b []byte) (n int, err error) {
+func (p *headerReader) Read(b []byte) (int, error) {
 	// read from header first
 	if len(p.header) > 0 {
-		n = copy(b, p.header)
+		n := copy(b, p.header)
 		p.header = p.header[n:]
 		return n, nil
 	}


### PR DESCRIPTION
This PR adds a small `io.Reader` implementation that allows you to 

1. Buffer the header in memory, where you get to define how long that header should be
2. Then `.Read()` the entire file, including the header, like you'd expect from a normal `io.Reader`.

What this allows is for an archive file's "magic bytes" to be read without having to `.Read()` the entire file's contents. Initializing the `headerReader` reads _just enough_ of the file to make the archive type determination, but then allows that header data to be included when it is handed off to the unpacking implementation.

As a general-purpose library, its important to try and minimize the memory footprint and wherever possible not put the entire archive file into memory. Otherwise it can become a DoS vector in a live service.