### PR TITLE
Separate option for file ownership preservation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 

--- a/config.go
+++ b/config.go
@@ -248,6 +248,7 @@ const (
 	defaultNoUntarAfterDecompression  = false         // untar after decompression
 	defaultOverwrite                  = false         // do not overwrite existing files
 	defaultPreserveFileAttributes     = false         // do not preserve file attributes
+	defaultPreserveFileOwnership      = false         // do not preserve file ownership
 	defaultTraverseSymlinks           = false         // do not traverse symlinks
 
 )
@@ -284,6 +285,7 @@ func NewConfig(opts ...ConfigOption) *Config {
 		traverseSymlinks:           defaultTraverseSymlinks,
 		noUntarAfterDecompression:  defaultNoUntarAfterDecompression,
 		preserveFileAttributes:     defaultPreserveFileAttributes,
+		preserveFileOwnership:      defaultPreserveFileOwnership,
 	}
 
 	// Loop through each option

--- a/config.go
+++ b/config.go
@@ -79,6 +79,9 @@ type Config struct {
 
 	// preserveFileAttributes is a flag to preserve the file attributes of the extracted files
 	preserveFileAttributes bool
+
+	// preserveFileOwnership is a flag to preserve the file ownership of the extracted files.
+	preserveFileOwnership bool
 }
 
 // ContinueOnError returns true if the extraction should continue on error.
@@ -207,6 +210,11 @@ func (c *Config) Patterns() []string {
 // PreserveFileAttributes returns true if the file attributes of the extracted files should be preserved.
 func (c *Config) PreserveFileAttributes() bool {
 	return c.preserveFileAttributes
+}
+
+// PreserveFileOwnership returns true if the file ownership of the extracted files should be preserved.
+func (c *Config) PreserveFileOwnership() bool {
+	return c.preserveFileOwnership
 }
 
 // SetNoUntarAfterDecompression sets the noUntarAfterDecompression flag. If true, tar.gz files
@@ -415,10 +423,22 @@ func WithPatterns(pattern ...string) ConfigOption {
 	}
 }
 
-// WithPreserveFileAttributes options pattern function to preserve the file attributes of the extracted files.
+// WithPreserveFileAttributes means preserve the attributes of the extracted files.
+// This includes the file mode, access and modified times, but does not include ownership UID/GID.
+//
+// This option is only available on Unix systems.
 func WithPreserveFileAttributes(preserve bool) ConfigOption {
 	return func(c *Config) {
 		c.preserveFileAttributes = preserve
+	}
+}
+i
+// WithPreserveFileOwnership means preserve the ownership UID/GID of the extracted files.
+// This option is only available on Unix systems and requires root privileges.
+// If either of these requirements are not met, this will result in an error.
+func WithPreserveFileOwnership(preserve bool) ConfigOption {
+	return func(c *Config) {
+		c.preserveFileOwnership = preserve
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -434,7 +434,7 @@ func WithPreserveFileAttributes(preserve bool) ConfigOption {
 		c.preserveFileAttributes = preserve
 	}
 }
-i
+
 // WithPreserveFileOwnership means preserve the ownership UID/GID of the extracted files.
 // This option is only available on Unix systems and requires root privileges.
 // If either of these requirements are not met, this will result in an error.

--- a/extractor.go
+++ b/extractor.go
@@ -364,7 +364,7 @@ func extract(ctx context.Context, t Target, dst string, src archiveWalker, cfg *
 				// do not end on error
 				continue
 			}
-			if cfg.PreserveFileAttributes() {
+			if cfg.PreserveFileAttributes() || cfg.PreserveFileOwnership() {
 				extractedEntries = append(extractedEntries, ae)
 			}
 
@@ -407,7 +407,7 @@ func extract(ctx context.Context, t Target, dst string, src archiveWalker, cfg *
 			// store telemetry
 			if fileCreated {
 				td.ExtractedFiles++
-				if cfg.PreserveFileAttributes() {
+				if cfg.PreserveFileAttributes() || cfg.PreserveFileOwnership() {
 					extractedEntries = append(extractedEntries, ae)
 				}
 			}
@@ -438,7 +438,7 @@ func extract(ctx context.Context, t Target, dst string, src archiveWalker, cfg *
 				// do not end on error
 				continue
 			}
-			if cfg.PreserveFileAttributes() {
+			if cfg.PreserveFileAttributes() || cfg.PreserveFileOwnership() {
 				extractedEntries = append(extractedEntries, ae)
 			}
 

--- a/unpack_unix_test.go
+++ b/unpack_unix_test.go
@@ -102,3 +102,87 @@ func TestUnpackWithPreserveFileAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestUnpackWithPreserveFileOwnership(t *testing.T) {
+
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root permissions")
+	}
+
+	uid, gid := 503, 20
+	baseTime := time.Date(2021, 1, 1, 0, 0, 0, 0, time.Local)
+	testCases := []struct {
+		name                  string
+		contents              []archiveContent
+		packer                func(*testing.T, []archiveContent) []byte
+		doesNotSupportModTime bool
+		doesNotSupportOwner   bool
+		expectError           bool
+	}{
+		{
+			name: "tar",
+			contents: []archiveContent{
+				{Name: "test", Content: []byte("hello world"), Mode: 0777, AccessTime: baseTime, ModTime: baseTime, Uid: 0, Gid: 0},
+				{Name: "sub", Mode: fs.ModeDir | 0777, AccessTime: baseTime, ModTime: baseTime, Uid: uid, Gid: gid},
+				{Name: "sub/test", Content: []byte("hello world"), Mode: 0777, AccessTime: baseTime, ModTime: baseTime, Uid: uid, Gid: gid},
+				{Name: "link", Mode: fs.ModeSymlink | 0777, Linktarget: "sub/test", AccessTime: baseTime, ModTime: baseTime},
+			},
+			packer: packTar,
+		},
+		{
+			name: "zip",
+			contents: []archiveContent{
+				{Name: "test", Content: []byte("hello world"), Mode: 0777, AccessTime: baseTime, ModTime: baseTime, Uid: uid, Gid: gid},
+				{Name: "sub", Mode: fs.ModeDir | 0777, AccessTime: baseTime, ModTime: baseTime, Uid: uid, Gid: gid},
+				{Name: "sub/test", Content: []byte("hello world"), Mode: 0644, AccessTime: baseTime, ModTime: baseTime, Uid: uid, Gid: gid},
+				{Name: "link", Mode: fs.ModeSymlink | 0777, Linktarget: "sub/test", AccessTime: baseTime, ModTime: baseTime},
+			},
+			doesNotSupportOwner: true,
+			packer:              packZip,
+		},
+		{
+			name:                  "rar",
+			contents:              contentsRar2,
+			packer:                packRar2,
+			doesNotSupportModTime: true,
+		},
+		{
+			name:                "7z",
+			contents:            contents7z2,
+			doesNotSupportOwner: true,
+			packer:              pack7z2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				ctx = context.Background()
+				dst = t.TempDir()
+				src = asIoReader(t, tc.packer(t, tc.contents))
+				cfg = extract.NewConfig(extract.WithPreserveFileOwnership(true))
+			)
+			if err := extract.Unpack(ctx, dst, src, cfg); err != nil {
+				t.Fatalf("error unpacking archive: %v", err)
+			}
+			for _, c := range tc.contents {
+				path := filepath.Join(dst, c.Name)
+				stat, err := os.Lstat(path)
+				if err != nil {
+					t.Fatalf("error getting file stats: %v", err)
+				}
+				if !(c.Mode&fs.ModeSymlink != 0) { // skip symlink checks
+					if stat.Mode().Perm() != c.Mode.Perm() {
+						t.Fatalf("expected file mode %v, got %v, file %s", c.Mode.Perm(), stat.Mode().Perm(), c.Name)
+					}
+				}
+				if tc.doesNotSupportOwner {
+					continue
+				}
+				if stat.Sys().(*syscall.Stat_t).Uid != uint32(c.Uid) {
+					t.Fatalf("expected uid %d, got %d, file %s", c.Uid, stat.Sys().(*syscall.Stat_t).Uid, c.Name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This separates out the configuration for preserving file ownership vs other attributes. Preserving ownership requires root permissions, and attempting to do that without root permissions now fails instead of just warning. The rationale for separating the options rather than just requiring root to preserve any of the attributes is that there are many use cases where the file mode and modification times are important, but where file ownership is not. This way users can benefit from these attributes without needing root privileges.